### PR TITLE
refine `keyboardShortcut`

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -20,12 +20,13 @@ export type EditorMethods = {
 };
 
 type EditorProps = {
+  onToggleInformation?: () => void;
   onToggleTheme?: () => void;
   darkMode?: boolean;
 };
 
 const Editor = React.forwardRef<EditorMethods, EditorProps>(
-  ({ onToggleTheme, darkMode }, ref) => {
+  ({ onToggleInformation, onToggleTheme, darkMode }, ref) => {
   const text = DATA1;
 
   const format = (
@@ -87,6 +88,12 @@ const Editor = React.forwardRef<EditorMethods, EditorProps>(
     }
   };
 
+  const toggleInformation = () => {
+    if (onToggleInformation) {
+      onToggleInformation();
+    }
+  };
+
   const toggleEditorTheme = () => {
     // @ts-expect-error Not defined on type
     const currentTheme = editorRef.current._themeService._theme.themeName;
@@ -123,7 +130,7 @@ const Editor = React.forwardRef<EditorMethods, EditorProps>(
 
   useImperativeHandle(
     ref,
-    () => ({ formatEditorContent, copyEditorContent, toggleTheme, toggleEditorTheme, getShareableLink }),
+    () => ({ formatEditorContent, copyEditorContent, toggleTheme, toggleInformation, toggleEditorTheme, getShareableLink }),
     []
   );
 
@@ -152,21 +159,20 @@ const Editor = React.forwardRef<EditorMethods, EditorProps>(
       monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
       formatEditorContent
     );
-  
-    // Theme
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyM, toggleTheme);
-  
-    // Shareable Link
-    editor.addCommand(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyL,
-      getShareableLink
-    );
-
     // Copy JSON
     editor.addCommand(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyJ,
       copyEditorContent
     );
+    // Shareable Link
+    editor.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
+      getShareableLink
+    );
+    // Toggle Theme
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyB, toggleTheme);
+    // Toggle Information
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyU, toggleInformation);
 
     // Load custom themes
     monaco.editor.defineTheme(THEMES.dark, THEME_P_DARK);

--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -41,25 +41,25 @@ export default function Overlay({ darkMode }: OverlayProps) {
               <div className="line">
                 <span>To copy your formatted JSON blob to your clipboard, press</span>
                 <KeyboardShortcut color="button">
-                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> K
+                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> J
                 </KeyboardShortcut>
               </div>
               <div className="line">
                 <span>To generate a shareable, public link to your JSON blob, press</span>
                 <KeyboardShortcut color="button">
-                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> L
+                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> K
                 </KeyboardShortcut>
               </div>
               <div className="line">
                 <span>To toggle the information overlay (for links and shortcuts) press</span>
                 <KeyboardShortcut color="button">
-                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> J
+                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> U
                 </KeyboardShortcut>
               </div>
               <div className="line">
                 <span>To switch between <InlineTag>Light</InlineTag> and <InlineTag>Dark</InlineTag> color modes, press</span>
                 <KeyboardShortcut color="button">
-                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> M
+                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus /> B
                 </KeyboardShortcut>
               </div>
               <div className="line">

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -59,16 +59,14 @@ export const ToastProvider = ({ children, defaultDelay = 1500 }: ToastProviderPr
               className={`toast ${toastOptions.error ? 'error' : ''}`}
               exit={{
                 y: 56,
-
                 filter: "blur(4px)",
-                transition: { type: "spring", duration: 0.64 }
+                transition: { type: "spring", duration: 0.56 }
               }}
               initial={{ y: 56 }}
               animate={{
-
                 y: 0,
                 filter: "blur(0px)",
-                transition: { type: "spring", duration: 0.64 }
+                transition: { type: "spring", duration: 0.56 }
               }}
             >
               {toastContent}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,16 +68,16 @@ export default function Home() {
   };
 
   // Keyboard Shortcuts
-  useKeyPress('meta.j', () => {
+  useKeyPress('meta.u', () => {
     onInfoButton();
   });
-  useKeyPress('meta.k', () => {
+  useKeyPress('meta.j', () => {
     onCopyButton();
   });
-  useKeyPress('meta.l', () => {
+  useKeyPress('meta.k', () => {
     onShareableLinkButton();
   });
-  useKeyPress('meta.m', () => {
+  useKeyPress('meta.b', () => {
     onThemeButton();
   });
   useKeyPress('meta.enter', () => {
@@ -97,19 +97,19 @@ export default function Home() {
       </Head>
       <main ref={editorElementRef}>
         <ClientOnly>
-          <Editor ref={editorRef} onToggleTheme={onThemeButton} darkMode={isDarkMode} />
+          <Editor ref={editorRef} onToggleInformation={onInfoButton} onToggleTheme={onThemeButton} darkMode={isDarkMode} />
           {showInfo && <Overlay darkMode={isDarkMode} />}
           <TopButtons>
             <Button onClick={onInfoButton} className={showInfo ? "active" : ""} color="secondary" hasShortcut>
               Information
               <KeyboardShortcut color="secondary">
-                {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> J
+                {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> U
               </KeyboardShortcut>
             </Button>
               <Button onClick={onThemeButton} color="secondary" hasShortcut>
                 {isDarkMode ? 'Dark' : 'Light'} Mode
                 <KeyboardShortcut color="secondary">
-                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> M
+                  {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> B
                 </KeyboardShortcut>
               </Button>
           </TopButtons>
@@ -123,13 +123,13 @@ export default function Home() {
             <Button onClick={onCopyButton} hasShortcut>
               Copy JSON
               <KeyboardShortcut>
-                {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> K
+                {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> J
               </KeyboardShortcut>
             </Button>
             <Button onClick={onShareableLinkButton} hasShortcut>
               Shareable Link
               <KeyboardShortcut>
-                {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> L
+                {isMacOs ? '⌘' : 'Ctrl'} <KeyboardPlus/> K
               </KeyboardShortcut>
             </Button>
           </Toolbar>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,19 +68,19 @@ export default function Home() {
   };
 
   // Keyboard Shortcuts
-  useKeyPress('meta.u', () => {
+  useKeyPress(isMacOs ? 'meta.u' : 'ctrl.u', () => {
     onInfoButton();
   });
-  useKeyPress('meta.j', () => {
+  useKeyPress(isMacOs ? 'meta.j' : 'ctrl.j', () => {
     onCopyButton();
   });
-  useKeyPress('meta.k', () => {
+  useKeyPress(isMacOs ? 'meta.k' : 'ctrl.k', () => {
     onShareableLinkButton();
   });
-  useKeyPress('meta.b', () => {
+  useKeyPress(isMacOs ? 'meta.b' : 'ctrl.b', () => {
     onThemeButton();
   });
-  useKeyPress('meta.enter', () => {
+  useKeyPress(isMacOs ? 'meta.enter' : 'ctrl.enter', () => {
     onFormatButton();
   });
 

--- a/styles/components/buttons.css
+++ b/styles/components/buttons.css
@@ -72,3 +72,10 @@ button:active {
 .light button.secondary.active {
   color: hsl(240, 3%, 2%);
 }
+
+/* Normalise margins on mobile, tablet devices */
+@media screen and (max-width: 767px) {
+  button.has-shortcut {
+    padding: 0 14px;
+  }
+}

--- a/styles/components/keyboard-shortcut.css
+++ b/styles/components/keyboard-shortcut.css
@@ -16,6 +16,10 @@
   font-feature-settings: "cv11" on, "cv01" on;
 }
 
+.keyboard-shortcut svg {
+  margin-right: 1px;
+}
+
 /* Dark */
 
 .dark .keyboard-shortcut.primary {
@@ -66,4 +70,12 @@
 }
 .light .keyboard-shortcut.button svg path {
   fill: hsla(240, 3%, 30%, 0.64);
+}
+
+/* Hide on mobile, tablet devices */
+
+@media screen and (max-width: 767px) {
+  .keyboard-shortcut {
+    display: none;
+  }
 }


### PR DESCRIPTION
- Uses keyboard shortcuts that do not interfere with browser default functionality
- Hides `KeyboardShortcut` markup on smaller screens